### PR TITLE
Fix typo in comment

### DIFF
--- a/Classes/MTZWhatsNew.h
+++ b/Classes/MTZWhatsNew.h
@@ -47,7 +47,7 @@ typedef void (^MTZWhatsNewHandler)(NSDictionary *whatsNew);
 /// @discussion Call this on every app launch to keep track of used versions.
 + (void)handleWhatsNew:(MTZWhatsNewHandler)whatsNewBlock;
 
-///	Clears the last migration remembered by @c MTZWhatsNew. Causes all migration to run from the beginning.
+///	Clears the last migration remembered by @c MTZWhatsNew. Causes migration to run from the beginning.
 + (void)reset;
 
 @end


### PR DESCRIPTION
So crazy story... I happened to see this pod on the cocoapods feed, and for no reason in particular I happened to look at your code and realized it looked awfully familiar in places. I then realized that the migration logic looks to have been taken from [MTMigration](https://github.com/mysterioustrousers/MTMigration), which I wrote, including a typo in this comment! I didn't notice the typo until now, so I [just fixed it](https://github.com/mysterioustrousers/MTMigration/commit/c3fc6a322cdf8fd87e6b94960b7a22913ace6b1d) in MTMigration and thought I'd make a PR to fix this one real quick too. The exception being that I think there's only one managed migration for this library, so I made it singular instead of plural.

Cool lib, and a small world!
