### PR TITLE
Fix for scrolling determination

### DIFF
--- a/Classes/MTZWhatsNewViewController/MTZCollectionView.m
+++ b/Classes/MTZWhatsNewViewController/MTZCollectionView.m
@@ -12,7 +12,19 @@
 
 - (void)determineScrollingAbility
 {
-	self.scrollEnabled = self.contentSize.height > self.frame.size.height || self.contentSize.width > self.frame.size.width;
+    int buttonHeight;
+    if(self.frame.size.height >= 620 && self.frame.size.width >= 540) {
+        buttonHeight = 82;
+    } else {
+        buttonHeight = 50;
+    }
+    
+    if (self.contentSize.height <= self.frame.size.height - buttonHeight &&
+        self.contentSize.width <= self.frame.size.width) {
+        self.scrollEnabled = NO;
+    } else {
+        self.scrollEnabled = YES;
+    }
 }
 
 @end

--- a/MTZWhatsNew.podspec
+++ b/MTZWhatsNew.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "MTZWhatsNew"
-  s.version      = "1.1"
+  s.version      = "1.1.1"
   s.summary      = "Easily present the latest changes and features to your users on app updates."
 
   s.description  = <<-DESC


### PR DESCRIPTION
Previously, we weren’t accounting for the button height when judging if
the view should be scrollable.