### PR TITLE
 Fixed iOS 11 bug with not working button

### DIFF
--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -86,7 +86,7 @@
     self.buttonBackground.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.buttonBackground toEdges:UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight]];
     
-    {//add blur effect & hairline
+    /* Blur Effect & Hairline */ {
         UIVisualEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
         UIVisualEffectView *blurView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
         [self.buttonBackground addSubview:blurView];
@@ -98,7 +98,8 @@
         [self.buttonBackground addSubview:hair];
         hair.translatesAutoresizingMaskIntoConstraints = NO;
         [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:hair toEdges:UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight]];
-        [hair addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:1.f toView:hair]];
+        CGFloat lineThickness = 1.f / [[UIScreen mainScreen] scale];
+        [hair addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:lineThickness toView:hair]];
     }
 	
 	self.dismissButton = [[UIButton alloc] init];

--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -82,12 +82,17 @@
 	
     // Dismiss Button.
     self.buttonBackground = [[UIView alloc] init];
-    self.buttonBackground.backgroundColor = [UIColor colorWithWhite:0.97f alpha:0.9f];
     [self.view addSubview:self.buttonBackground];
     self.buttonBackground.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.buttonBackground toEdges:UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight]];
     
-    {//add hairline
+    {//add blur effect & hairline
+        UIVisualEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
+        UIVisualEffectView *blurView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+        [self.buttonBackground addSubview:blurView];
+        blurView.translatesAutoresizingMaskIntoConstraints = NO;
+        [self.view addConstraints:[NSLayoutConstraint constraintsToFillToSuperview:blurView]];
+        
         UIView *hair = [[UIView alloc] init];
         hair.backgroundColor = [UIColor colorWithWhite:0.87f alpha:1];
         [self.buttonBackground addSubview:hair];

--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -24,7 +24,7 @@
 @property (nonatomic, strong) UIButton *dismissButton;
 
 ///	The background behind the dismiss button.
-@property (nonatomic, strong) UIToolbar *buttonBackground;
+@property (nonatomic, strong) UIView *buttonBackground;
 
 @end
 
@@ -80,11 +80,21 @@
 	self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
 	[self.view addConstraints:[NSLayoutConstraint constraintsToFillToSuperview:self.contentView]];
 	
-	// Dismiss Button.
-	self.buttonBackground = [[UIToolbar alloc] init];
-	[self.view addSubview:self.buttonBackground];
-	self.buttonBackground.translatesAutoresizingMaskIntoConstraints = NO;
-	[self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.buttonBackground toEdges:UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight]];
+    // Dismiss Button.
+    self.buttonBackground = [[UIView alloc] init];
+    self.buttonBackground.backgroundColor = [UIColor colorWithWhite:0.97f alpha:0.9f];
+    [self.view addSubview:self.buttonBackground];
+    self.buttonBackground.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.buttonBackground toEdges:UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight]];
+    
+    {//add hairline
+        UIView *hair = [[UIView alloc] init];
+        hair.backgroundColor = [UIColor colorWithWhite:0.87f alpha:1];
+        [self.buttonBackground addSubview:hair];
+        hair.translatesAutoresizingMaskIntoConstraints = NO;
+        [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:hair toEdges:UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight]];
+        [hair addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:1.f toView:hair]];
+    }
 	
 	self.dismissButton = [[UIButton alloc] init];
 	self.dismissButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];

--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -26,6 +26,9 @@
 ///	The background behind the dismiss button.
 @property (nonatomic, strong) UIView *buttonBackground;
 
+// Reference to button height constraint
+@property (nonatomic, weak) NSLayoutConstraint *buttonHeightConstraint;
+
 @end
 
 
@@ -92,7 +95,6 @@
         [self.buttonBackground addSubview:blurView];
         blurView.translatesAutoresizingMaskIntoConstraints = NO;
         [self.view addConstraints:[NSLayoutConstraint constraintsToFillToSuperview:blurView]];
-        
         UIView *hair = [[UIView alloc] init];
         hair.backgroundColor = [UIColor colorWithWhite:0.87f alpha:1];
         [self.buttonBackground addSubview:hair];
@@ -101,12 +103,15 @@
         CGFloat lineThickness = 1.f / [[UIScreen mainScreen] scale];
         [hair addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:lineThickness toView:hair]];
     }
-	
-	self.dismissButton = [[UIButton alloc] init];
-	self.dismissButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-	[self.buttonBackground addSubview:self.dismissButton];
-	self.dismissButton.translatesAutoresizingMaskIntoConstraints = NO;
-	[self.dismissButton addTarget:self action:@selector(didTapContinueButton:) forControlEvents:UIControlEventTouchUpInside];
+    
+    self.dismissButton = [UIButton new];
+    self.dismissButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+    [self.buttonBackground addSubview:self.dismissButton];
+    self.dismissButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.dismissButton addTarget:self action:@selector(didTapContinueButton:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.buttonBackground attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.dismissButton attribute:NSLayoutAttributeTop  multiplier:1.0 constant:0]];
+    [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.dismissButton attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.bottomLayoutGuide attribute:NSLayoutAttributeTop  multiplier:1.0 constant:0]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.dismissButton toEdges:UIRectEdgeLeft|UIRectEdgeRight]];
 	
 	[self reloadButtonHeight];
 	
@@ -123,10 +128,12 @@
 	UIFont *buttonFont = [self shouldUseLargeButton] ? [UIFont systemFontOfSize:29.0f weight:UIFontWeightLight] : [UIFont systemFontOfSize:18.0f weight:UIFontWeightRegular];
 	self.dismissButton.titleLabel.font = buttonFont;
 	
-	CGFloat buttonHeight = [self shouldUseLargeButton] ? 82.0f : 50.0f;
-	[self.buttonBackground removeConstraints:self.buttonBackground.constraints];
-	[self.buttonBackground addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:buttonHeight toView:self.buttonBackground]];
-	[self.buttonBackground addConstraints:[NSLayoutConstraint constraintsToFillToSuperview:self.dismissButton]];
+    [self.view removeConstraint:self.buttonHeightConstraint];
+    CGFloat buttonHeight = [self shouldUseLargeButton] ? 82.0f : 50.0f;
+    
+    NSLayoutConstraint *buttonHeightConstraint = [NSLayoutConstraint constraintWithItem:self.dismissButton attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:0 multiplier:1.0f constant:buttonHeight];
+    [self.view addConstraint:buttonHeightConstraint];
+    self.buttonHeightConstraint = buttonHeightConstraint;
 	
 	self.contentInset = UIEdgeInsetsMake(self.topLayoutGuide.length, 0, self.bottomLayoutGuide.length + buttonHeight, 0);
 }

--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -27,7 +27,7 @@
 @property (nonatomic, strong) UIView *buttonBackground;
 
 // Reference to button height constraint
-@property (nonatomic, weak) NSLayoutConstraint *buttonHeightConstraint;
+@property (nonatomic, strong) NSLayoutConstraint *buttonHeightConstraint;
 
 @end
 
@@ -113,6 +113,9 @@
     [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.dismissButton attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.bottomLayoutGuide attribute:NSLayoutAttributeTop  multiplier:1.0 constant:0]];
     [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.dismissButton toEdges:UIRectEdgeLeft|UIRectEdgeRight]];
 	
+    self.buttonHeightConstraint = [NSLayoutConstraint constraintWithItem:self.dismissButton attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:0 multiplier:1.0f constant:50];
+    [self.view addConstraint:self.buttonHeightConstraint];
+    
 	[self reloadButtonHeight];
 	
 	// Defaults.
@@ -128,12 +131,8 @@
 	UIFont *buttonFont = [self shouldUseLargeButton] ? [UIFont systemFontOfSize:29.0f weight:UIFontWeightLight] : [UIFont systemFontOfSize:18.0f weight:UIFontWeightRegular];
 	self.dismissButton.titleLabel.font = buttonFont;
 	
-    [self.view removeConstraint:self.buttonHeightConstraint];
     CGFloat buttonHeight = [self shouldUseLargeButton] ? 82.0f : 50.0f;
-    
-    NSLayoutConstraint *buttonHeightConstraint = [NSLayoutConstraint constraintWithItem:self.dismissButton attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:0 multiplier:1.0f constant:buttonHeight];
-    [self.view addConstraint:buttonHeightConstraint];
-    self.buttonHeightConstraint = buttonHeightConstraint;
+    self.buttonHeightConstraint.constant = buttonHeight;
 	
 	self.contentInset = UIEdgeInsetsMake(self.topLayoutGuide.length, 0, self.bottomLayoutGuide.length + buttonHeight, 0);
 }

--- a/Demo Apps/Podcasts/Podcasts/PDCAppDelegate.m
+++ b/Demo Apps/Podcasts/Podcasts/PDCAppDelegate.m
@@ -38,8 +38,8 @@
 		// Creating the view controller with features.
 		MTZWhatsNewGridViewController *vc = [[MTZWhatsNewGridViewController alloc] initWithFeatures:whatsNew];
 		// Customizing the background gradient.
-		vc.backgroundGradientTopColor = [UIColor colorWithHue:0.77 saturation:0.77 brightness:0.76 alpha:1];
-		vc.backgroundGradientBottomColor = [UIColor colorWithHue:0.78 saturation:0.6 brightness:0.95 alpha:1];
+        vc.backgroundGradientTopColor = [UIColor colorWithHue:0.77 saturation:0.77 brightness:0.76 alpha:1];
+        vc.backgroundGradientBottomColor = [UIColor colorWithHue:0.78 saturation:0.6 brightness:0.95 alpha:1];
 		// Presenting the what’s new view controller.
 		[self.window.rootViewController presentViewController:vc animated:NO completion:nil];
 		// vc.view.superview.frame = CGRectMake(40, 40, 320, 568);

--- a/Demo Apps/Podcasts/Podcasts/PDCAppDelegate.m
+++ b/Demo Apps/Podcasts/Podcasts/PDCAppDelegate.m
@@ -38,8 +38,8 @@
 		// Creating the view controller with features.
 		MTZWhatsNewGridViewController *vc = [[MTZWhatsNewGridViewController alloc] initWithFeatures:whatsNew];
 		// Customizing the background gradient.
-        vc.backgroundGradientTopColor = [UIColor colorWithHue:0.77 saturation:0.77 brightness:0.76 alpha:1];
-        vc.backgroundGradientBottomColor = [UIColor colorWithHue:0.78 saturation:0.6 brightness:0.95 alpha:1];
+		vc.backgroundGradientTopColor = [UIColor colorWithHue:0.77 saturation:0.77 brightness:0.76 alpha:1];
+		vc.backgroundGradientBottomColor = [UIColor colorWithHue:0.78 saturation:0.6 brightness:0.95 alpha:1];
 		// Presenting the what’s new view controller.
 		[self.window.rootViewController presentViewController:vc animated:NO completion:nil];
 		// vc.view.superview.frame = CGRectMake(40, 40, 320, 568);


### PR DESCRIPTION
Problem: UIToolbar making another layer on top of UIButton which obstructs actions to pass through

Solution: Replaced UIToolbar with UIView having UIBlurEffect and hairline

To fix iPhone X button issue, created #29 pull request