### PR TITLE
iPhone X adjustment

### DIFF
--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -86,7 +86,7 @@
     self.buttonBackground.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.buttonBackground toEdges:UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight]];
     
-    {//add blur effect & hairline
+    /* Blur Effect & Hairline */ {
         UIVisualEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
         UIVisualEffectView *blurView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
         [self.buttonBackground addSubview:blurView];
@@ -98,7 +98,8 @@
         [self.buttonBackground addSubview:hair];
         hair.translatesAutoresizingMaskIntoConstraints = NO;
         [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:hair toEdges:UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight]];
-        [hair addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:1.f toView:hair]];
+        CGFloat lineThickness = 1.f / [[UIScreen mainScreen] scale];
+        [hair addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:lineThickness toView:hair]];
     }
 	
 	self.dismissButton = [[UIButton alloc] init];

--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -82,12 +82,17 @@
 	
     // Dismiss Button.
     self.buttonBackground = [[UIView alloc] init];
-    self.buttonBackground.backgroundColor = [UIColor colorWithWhite:0.97f alpha:0.9f];
     [self.view addSubview:self.buttonBackground];
     self.buttonBackground.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.buttonBackground toEdges:UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight]];
     
-    {//add hairline
+    {//add blur effect & hairline
+        UIVisualEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
+        UIVisualEffectView *blurView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+        [self.buttonBackground addSubview:blurView];
+        blurView.translatesAutoresizingMaskIntoConstraints = NO;
+        [self.view addConstraints:[NSLayoutConstraint constraintsToFillToSuperview:blurView]];
+        
         UIView *hair = [[UIView alloc] init];
         hair.backgroundColor = [UIColor colorWithWhite:0.87f alpha:1];
         [self.buttonBackground addSubview:hair];

--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -24,7 +24,7 @@
 @property (nonatomic, strong) UIButton *dismissButton;
 
 ///	The background behind the dismiss button.
-@property (nonatomic, strong) UIToolbar *buttonBackground;
+@property (nonatomic, strong) UIView *buttonBackground;
 
 @end
 
@@ -80,11 +80,21 @@
 	self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
 	[self.view addConstraints:[NSLayoutConstraint constraintsToFillToSuperview:self.contentView]];
 	
-	// Dismiss Button.
-	self.buttonBackground = [[UIToolbar alloc] init];
-	[self.view addSubview:self.buttonBackground];
-	self.buttonBackground.translatesAutoresizingMaskIntoConstraints = NO;
-	[self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.buttonBackground toEdges:UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight]];
+    // Dismiss Button.
+    self.buttonBackground = [[UIView alloc] init];
+    self.buttonBackground.backgroundColor = [UIColor colorWithWhite:0.97f alpha:0.9f];
+    [self.view addSubview:self.buttonBackground];
+    self.buttonBackground.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:self.buttonBackground toEdges:UIRectEdgeLeft | UIRectEdgeBottom | UIRectEdgeRight]];
+    
+    {//add hairline
+        UIView *hair = [[UIView alloc] init];
+        hair.backgroundColor = [UIColor colorWithWhite:0.87f alpha:1];
+        [self.buttonBackground addSubview:hair];
+        hair.translatesAutoresizingMaskIntoConstraints = NO;
+        [self.view addConstraints:[NSLayoutConstraint constraintsToStickView:hair toEdges:UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight]];
+        [hair addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:1.f toView:hair]];
+    }
 	
 	self.dismissButton = [[UIButton alloc] init];
 	self.dismissButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];

--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -123,7 +123,13 @@
 	UIFont *buttonFont = [self shouldUseLargeButton] ? [UIFont systemFontOfSize:29.0f weight:UIFontWeightLight] : [UIFont systemFontOfSize:18.0f weight:UIFontWeightRegular];
 	self.dismissButton.titleLabel.font = buttonFont;
 	
+    CGFloat safeY = CGRectGetMaxY(self.view.safeAreaLayoutGuide.layoutFrame);
+    CGFloat layoutY = CGRectGetMaxY(self.view.frame);
+    CGFloat pushUp = layoutY - safeY;
+    self.dismissButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, pushUp, 0);
+    
 	CGFloat buttonHeight = [self shouldUseLargeButton] ? 82.0f : 50.0f;
+    buttonHeight += pushUp;
 	[self.buttonBackground removeConstraints:self.buttonBackground.constraints];
 	[self.buttonBackground addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:buttonHeight toView:self.buttonBackground]];
 	[self.buttonBackground addConstraints:[NSLayoutConstraint constraintsToFillToSuperview:self.dismissButton]];

--- a/Demo Apps/Podcasts/Podcasts/PDCAppDelegate.m
+++ b/Demo Apps/Podcasts/Podcasts/PDCAppDelegate.m
@@ -38,8 +38,8 @@
 		// Creating the view controller with features.
 		MTZWhatsNewGridViewController *vc = [[MTZWhatsNewGridViewController alloc] initWithFeatures:whatsNew];
 		// Customizing the background gradient.
-		vc.backgroundGradientTopColor = [UIColor colorWithHue:0.77 saturation:0.77 brightness:0.76 alpha:1];
-		vc.backgroundGradientBottomColor = [UIColor colorWithHue:0.78 saturation:0.6 brightness:0.95 alpha:1];
+        vc.backgroundGradientTopColor = [UIColor colorWithHue:0.77 saturation:0.77 brightness:0.76 alpha:1];
+        vc.backgroundGradientBottomColor = [UIColor colorWithHue:0.78 saturation:0.6 brightness:0.95 alpha:1];
 		// Presenting the what’s new view controller.
 		[self.window.rootViewController presentViewController:vc animated:NO completion:nil];
 		// vc.view.superview.frame = CGRectMake(40, 40, 320, 568);

--- a/Demo Apps/Podcasts/Podcasts/PDCAppDelegate.m
+++ b/Demo Apps/Podcasts/Podcasts/PDCAppDelegate.m
@@ -38,8 +38,8 @@
 		// Creating the view controller with features.
 		MTZWhatsNewGridViewController *vc = [[MTZWhatsNewGridViewController alloc] initWithFeatures:whatsNew];
 		// Customizing the background gradient.
-        vc.backgroundGradientTopColor = [UIColor colorWithHue:0.77 saturation:0.77 brightness:0.76 alpha:1];
-        vc.backgroundGradientBottomColor = [UIColor colorWithHue:0.78 saturation:0.6 brightness:0.95 alpha:1];
+		vc.backgroundGradientTopColor = [UIColor colorWithHue:0.77 saturation:0.77 brightness:0.76 alpha:1];
+		vc.backgroundGradientBottomColor = [UIColor colorWithHue:0.78 saturation:0.6 brightness:0.95 alpha:1];
 		// Presenting the what’s new view controller.
 		[self.window.rootViewController presentViewController:vc animated:NO completion:nil];
 		// vc.view.superview.frame = CGRectMake(40, 40, 320, 568);


### PR DESCRIPTION
Problem: Safe Area in iPhone X is smaller than actual view layout so text is partly obstructed by bottom slider

Solution: Increased Button's size and moved content ("Get Started" text) according to Safe Area size and position.

Before:
![x_before](https://user-images.githubusercontent.com/2383901/34898203-6d1a9a7c-f7b7-11e7-8071-e4e7484ddafa.png)


After:
![x_after](https://user-images.githubusercontent.com/2383901/34898205-6ffc4484-f7b7-11e7-91ff-6f13c4a256f7.png)