### PR TITLE
iPhone X Adjustment (iOS 11)

### DIFF
--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -107,7 +107,13 @@
 	UIFont *buttonFont = [self shouldUseLargeButton] ? [UIFont systemFontOfSize:29.0f weight:UIFontWeightLight] : [UIFont systemFontOfSize:18.0f weight:UIFontWeightRegular];
 	self.dismissButton.titleLabel.font = buttonFont;
 	
+    CGFloat safeY = CGRectGetMaxY(self.view.safeAreaLayoutGuide.layoutFrame);
+    CGFloat layoutY = CGRectGetMaxY(self.view.frame);
+    CGFloat pushUp = layoutY - safeY;
+    self.dismissButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, pushUp, 0);
+    
 	CGFloat buttonHeight = [self shouldUseLargeButton] ? 82.0f : 50.0f;
+    buttonHeight += pushUp;
 	[self.buttonBackground removeConstraints:self.buttonBackground.constraints];
 	[self.buttonBackground addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:buttonHeight toView:self.buttonBackground]];
 	[self.buttonBackground addConstraints:[NSLayoutConstraint constraintsToFillToSuperview:self.dismissButton]];

--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -107,10 +107,14 @@
 	UIFont *buttonFont = [self shouldUseLargeButton] ? [UIFont systemFontOfSize:29.0f weight:UIFontWeightLight] : [UIFont systemFontOfSize:18.0f weight:UIFontWeightRegular];
 	self.dismissButton.titleLabel.font = buttonFont;
 	
-    CGFloat safeY = CGRectGetMaxY(self.view.safeAreaLayoutGuide.layoutFrame);
-    CGFloat layoutY = CGRectGetMaxY(self.view.frame);
-    CGFloat pushUp = layoutY - safeY;
-    self.dismissButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, pushUp, 0);
+    CGFloat pushUp = 0;
+    if (@available(iOS 11.0, *))
+    {
+        CGFloat layoutY = CGRectGetMaxY(self.view.frame);
+        CGFloat safeAreaY = CGRectGetMaxY(self.view.safeAreaLayoutGuide.layoutFrame);
+        pushUp = layoutY - safeAreaY;
+        self.dismissButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, pushUp, 0);
+    }
     
 	CGFloat buttonHeight = [self shouldUseLargeButton] ? 82.0f : 50.0f;
     buttonHeight += pushUp;
@@ -118,7 +122,7 @@
 	[self.buttonBackground addConstraint:[NSLayoutConstraint constraintToSetStaticHeight:buttonHeight toView:self.buttonBackground]];
 	[self.buttonBackground addConstraints:[NSLayoutConstraint constraintsToFillToSuperview:self.dismissButton]];
 	
-	self.contentInset = UIEdgeInsetsMake(self.topLayoutGuide.length, 0, self.bottomLayoutGuide.length + buttonHeight, 0);
+	self.contentInset = UIEdgeInsetsMake(self.topLayoutGuide.length, 0, self.bottomLayoutGuide.length + buttonHeight - pushUp, 0);
 }
 
 - (BOOL)prefersStatusBarHidden

--- a/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
+++ b/Classes/MTZWhatsNewViewController/MTZWhatsNewViewController.m
@@ -107,7 +107,7 @@
 	UIFont *buttonFont = [self shouldUseLargeButton] ? [UIFont systemFontOfSize:29.0f weight:UIFontWeightLight] : [UIFont systemFontOfSize:18.0f weight:UIFontWeightRegular];
 	self.dismissButton.titleLabel.font = buttonFont;
 	
-    CGFloat pushUp = 0;
+    CGFloat pushUp = 0.f;
     if (@available(iOS 11.0, *))
     {
         CGFloat layoutY = CGRectGetMaxY(self.view.frame);


### PR DESCRIPTION
Problem: Safe Area in iPhone X is smaller than actual view layout so text is partly obstructed by bottom slider, so user can accidentally initiate slider, instead of button

Solution: Increased Button's size and moved content ("Get Started" text) according to Safe Area size and position.

Before:
![x_before](https://user-images.githubusercontent.com/2383901/34898203-6d1a9a7c-f7b7-11e7-8071-e4e7484ddafa.png)


After:
![x_after](https://user-images.githubusercontent.com/2383901/34898205-6ffc4484-f7b7-11e7-91ff-6f13c4a256f7.png)

Related to #27 